### PR TITLE
Add NSX-v Module as a Required Module

### DIFF
--- a/AsBuiltReport.psd1
+++ b/AsBuiltReport.psd1
@@ -53,6 +53,7 @@ RequiredModules = @(
         ModuleVersion = '0.7.24'
     },
     'AsBuiltReport.VMware.vSphere'
+	'AsBuiltReport.VMware.NSXv'
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
Add AsBuiltReport.VMware.NSXv as a required module in the AsBuiltReport manifest file