### PR TITLE
Add Pure Storage as a Required Module

### DIFF
--- a/AsBuiltReport.psd1
+++ b/AsBuiltReport.psd1
@@ -54,6 +54,7 @@ RequiredModules = @(
     },
     'AsBuiltReport.VMware.vSphere'
 	'AsBuiltReport.VMware.NSXv'
+	'AsBuiltReport.PureStorage.FlashArray'
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
- Add Pure Storage as a required module in the AsbuiltReport manifest file