### PR TITLE
Enhancements and Fixes to New-AsBuiltReport Function

### DIFF
--- a/Src/Public/New-AsBuiltConfig.ps1
+++ b/Src/Public/New-AsBuiltConfig.ps1
@@ -114,6 +114,9 @@ function New-AsBuiltConfig {
 
     #region Report Configuration Folder
     Clear-Host
+    #Write-Host '---------------------------------------------' -ForegroundColor Cyan
+    #Write-Host '  <     Report Configuration Folder       >  ' -ForegroundColor Cyan
+    #Write-Host '---------------------------------------------' -ForegroundColor Cyan
     Write-Host '---------------------------------------------' -ForegroundColor Cyan
     Write-Host ' <          Report Configuration           > ' -ForegroundColor Cyan
     Write-Host '---------------------------------------------' -ForegroundColor Cyan

--- a/Src/Public/New-AsBuiltConfig.ps1
+++ b/Src/Public/New-AsBuiltConfig.ps1
@@ -114,9 +114,6 @@ function New-AsBuiltConfig {
 
     #region Report Configuration Folder
     Clear-Host
-    #Write-Host '---------------------------------------------' -ForegroundColor Cyan
-    #Write-Host '  <     Report Configuration Folder       >  ' -ForegroundColor Cyan
-    #Write-Host '---------------------------------------------' -ForegroundColor Cyan
     Write-Host '---------------------------------------------' -ForegroundColor Cyan
     Write-Host ' <          Report Configuration           > ' -ForegroundColor Cyan
     Write-Host '---------------------------------------------' -ForegroundColor Cyan

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -217,13 +217,6 @@ function New-AsBuiltReport {
         if ($AsbuiltConfigPath) {
             if (Test-Path -Path $AsBuiltConfigPath) {
                 $Global:AsBuiltConfig = Get-Content -Path $AsBuiltConfigPath | ConvertFrom-Json
-                <#
-                if ($Timestamp) {
-                    $FileName = $Global:AsBuiltConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
-                } else {
-                    $FileName = $Global:AsBuiltConfig.Report.Name
-                }
-                #>
             }
         } else {
             $Global:AsBuiltConfig = New-AsBuiltConfig
@@ -254,20 +247,10 @@ function New-AsBuiltReport {
             
             if (Test-Path -Path $ReportConfigPath) {
                 $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
-                if ($Timestamp) {
-                    $FileName = $Global:ReportConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
-                } else {
-                    $FileName = $Global:ReportConfig.Report.Name
-                }
             } else {
                 # Create the report JSON and save it in the UserFolder specified in the Base Config
                 New-AsBuiltReportConfig -Report $Report -Path $AsBuiltConfig.UserFolder.Path
                 $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
-                if ($Timestamp) {
-                    $FileName = $Global:ReportConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
-                } else {
-                    $FileName = $Global:ReportConfig.Report.Name
-                }
             }#End if test-path
         }#End if ReportConfigPath
 

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -217,6 +217,13 @@ function New-AsBuiltReport {
         if ($AsbuiltConfigPath) {
             if (Test-Path -Path $AsBuiltConfigPath) {
                 $Global:AsBuiltConfig = Get-Content -Path $AsBuiltConfigPath | ConvertFrom-Json
+                <#
+                if ($Timestamp) {
+                    $FileName = $Global:AsBuiltConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
+                } else {
+                    $FileName = $Global:AsBuiltConfig.Report.Name
+                }
+                #>
             }
         } else {
             $Global:AsBuiltConfig = New-AsBuiltConfig
@@ -247,10 +254,20 @@ function New-AsBuiltReport {
             
             if (Test-Path -Path $ReportConfigPath) {
                 $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
+                if ($Timestamp) {
+                    $FileName = $Global:ReportConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
+                } else {
+                    $FileName = $Global:ReportConfig.Report.Name
+                }
             } else {
                 # Create the report JSON and save it in the UserFolder specified in the Base Config
                 New-AsBuiltReportConfig -Report $Report -Path $AsBuiltConfig.UserFolder.Path
                 $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
+                if ($Timestamp) {
+                    $FileName = $Global:ReportConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
+                } else {
+                    $FileName = $Global:ReportConfig.Report.Name
+                }
             }#End if test-path
         }#End if ReportConfigPath
 


### PR DESCRIPTION
Implement changes to support use of the -SendEmail parameter

Reimplement Register-ArgumentCompleter in New-AsbuiltReport to allow tab completion of the -Report parameter

Make Credential, Username and Password mandatory parameters

Clean up the section that converts $username and $password in to a $credential variable