### PR TITLE
Make default output folders consistent

### DIFF
--- a/Src/Public/New-AsBuiltConfig.ps1
+++ b/Src/Public/New-AsBuiltConfig.ps1
@@ -198,9 +198,9 @@ function New-AsBuiltConfig {
         if (($AsBuiltName -like $null) -or ($AsBuiltName -eq "")) {
             $AsBuiltName = "AsBuiltReport"
         }
-        $AsBuiltExportPath = Read-Host -Prompt "Enter the path to save the As Built report configuration file [$env:USERPROFILE]"
+        $AsBuiltExportPath = Read-Host -Prompt "Enter the path to save the As Built report configuration file [$env:USERPROFILE\AsBuiltReport]"
         if (($AsBuiltExportPath -like $null) -or ($AsBuiltExportPath -eq "")) {
-            $AsBuiltExportPath = $env:USERPROFILE
+            $AsBuiltExportPath = "$env:USERPROFILE\AsBuiltReport"
         }
         $AsBuiltConfigPath = Join-Path -Path $AsBuiltExportPath -ChildPath "$AsBuiltName.json"
         $Config | ConvertTo-Json | Out-File $AsBuiltConfigPath


### PR DESCRIPTION
## Description
Update `New-AsBuiltReport` menu to set the default output paths to the same folder `$env:USERPROFILE\AsBuiltReport`

## Motivation and Context
Improve functionality of New-AsBuiltReport

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
