### PR TITLE
Fix issue with generating custom report JSON configuration with New-AsBuiltReportConfig

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,16 +20,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**System (please provide the following information about the system from which you are trying to generate a report):**
+ - OS: [e.g. Windows 10]
+ - Windows PowerShell version [Provide output from the following command: `$PSVersionTable.PSVersion`]
+ - Vendor PowerShell Module name and version [e.g. VMware PowerCLI 11.2]
+ - AsBuiltReport version [e.g. 1.0.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/Src/Public/New-AsBuiltReportConfig.ps1
+++ b/Src/Public/New-AsBuiltReportConfig.ps1
@@ -1,9 +1,9 @@
 function New-AsBuiltReportConfig {
     <#
     .SYNOPSIS  
-        Creates As Built Report JSON configuration files.
+        Creates JSON configuration files for individual As Built Reports.
     .DESCRIPTION
-        Creates As Built Report JSON configuration files.
+        Creates JSON configuration files for individual As Built Reports.
     .PARAMETER Report
         Specifies the type of report configuration to create.
     .PARAMETER Path
@@ -55,13 +55,21 @@ function New-AsBuiltReportConfig {
     }
     # Find the root folder where the module is located for the report that has been specified
     try {
-        $Module = Get-Module "AsBuiltReport.$Report"
+        $Module = Get-Module -ListAvailable "AsBuiltReport.$Report"
         if ($Name) {
-            Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($Path)\$($Name).json" -Force
-            Write-Output "$Name JSON configuration file created in $Path"
+            if (!(Test-Path -Path "$($Path)\$($Name).json")) {
+                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($Path)\$($Name).json"
+                Write-Output "$Name JSON configuration file created in $Path"
+            } else {
+                Write-Error "$Name filename already exists in $Path"
+            }
         } else {
-            Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $Path -Force
-            Write-Output "$($Module.Name) JSON configuration file created in $Path"
+            if (!(Test-Path -Path "$($Module.ModuleBase)\$($Module.Name).json")) {
+                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $Path
+                Write-Output "$($Module.Name) JSON configuration file created in $Path"
+            } else {
+                Write-Error "$($Module.Name).json report configuration already exists in $Path"
+            }
         }
     } catch {
         Write-Error $_


### PR DESCRIPTION
## Description
Resolve issue with `New-AsBuiltReportConfig` cmdlet generating custom report configuration files.
Add error checking for file creation. Cmdlet will error if filename already exists.
Update bug/issue report template to remove irrelevant information

## Related Issue
Issue #20

## Motivation and Context
Resolve issue with generating custom JSON configuration files for reports

## How Has This Been Tested?
Run `New-AsBuiltReportConfig -Report VMware.vSphere -Path C:\scripts\ -Name TestReport`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
